### PR TITLE
Laker-like Navigation

### DIFF
--- a/Classes/RootViewController.h
+++ b/Classes/RootViewController.h
@@ -44,6 +44,7 @@
 	NSMutableArray *pages;
 	NSString *pageNameFromURL;
 	NSString *anchorFromURL;
+    NSString *navigationURL;
 	
 	UIScrollView *scrollView;
 	NSMutableArray *pageSpinners;
@@ -51,6 +52,7 @@
 	UIWebView *prevPage;
 	UIWebView *currPage;
 	UIWebView *nextPage;
+    UIWebView *navigation;
 	
 	CGRect upTapArea;
 	CGRect downTapArea;
@@ -80,6 +82,7 @@
 @property (nonatomic, retain) NSMutableArray *pages;
 @property (nonatomic, retain) NSString *pageNameFromURL;
 @property (nonatomic, retain) NSString *anchorFromURL;
+@property (nonatomic, retain) NSString *navigationURL;
 
 @property (nonatomic, retain) UIScrollView *scrollView;
 @property (nonatomic, retain) NSMutableArray *pageSpinners;
@@ -87,8 +90,11 @@
 @property (nonatomic, retain) UIWebView *prevPage;
 @property (nonatomic, retain) UIWebView *currPage;
 @property (nonatomic, retain) UIWebView *nextPage;
+@property (nonatomic, retain) UIWebView *navigation;
 
 @property int currentPageNumber;
+@property int pageWidth;
+@property int pageHeight;
 
 @property (nonatomic, retain) NSString *URLDownload;
 
@@ -96,6 +102,7 @@
 - (void)checkPageSize;
 - (void)setPageSize:(NSString *)orientation;
 - (void)initBook:(NSString *)path;
+- (void)initPageSize;
 
 // ****** LOADING
 - (BOOL)changePage:(int)page;

--- a/Classes/RootViewController.m
+++ b/Classes/RootViewController.m
@@ -500,7 +500,13 @@
 
 // ****** SCROLLVIEW
 - (CGRect)frameForPage:(int)page {
-	return CGRectMake(pageWidth * (page - 1), 0, pageWidth, pageHeight);
+    if (LAKER_NAVIGATION) {
+        if (navigation != nil && !navigation.hidden)
+            return CGRectMake(pageWidth * (page - 1), 0, pageWidth, pageHeight - 200);
+        else
+            return CGRectMake(pageWidth * (page - 1), 0, pageWidth, pageHeight - 200);
+    }
+    else return CGRectMake(pageWidth * (page - 1), 0, pageWidth, pageHeight);
 }
 - (void)spinnerForPage:(int)page isAnimating:(BOOL)isAnimating {
 	UIActivityIndicatorView *spinner = nil;

--- a/Classes/RootViewController.m
+++ b/Classes/RootViewController.m
@@ -220,9 +220,10 @@
 			[subview removeFromSuperview];
 		}
 	}
-
-	scrollView.contentSize = CGSizeMake(pageWidth * totalPages, pageHeight);
-	
+    if (LAKER_NAVIGATION && navigation != nil && !navigation.hidden)
+        scrollView.contentSize = CGSizeMake(pageWidth * totalPages, pageHeight - 200);
+	else
+        scrollView.contentSize = CGSizeMake(pageWidth * totalPages, pageHeight);
 	UIApplication *sharedApplication = [UIApplication sharedApplication];
 	int scrollViewY = 0;
 	if (!sharedApplication.statusBarHidden) {
@@ -905,6 +906,7 @@
                                  animations:^{
                                      navigation.hidden = NO;
                                      scrollView.frame = CGRectMake(0, 0, self.pageWidth, self.pageHeight - 200);
+                                     scrollView.contentSize = CGSizeMake(pageWidth * totalPages, pageHeight - 200);
                                      navigation.frame = CGRectMake(0,self.pageHeight - 200,self.pageWidth, 200);
                                  }
                                  completion:^(BOOL finished){
@@ -920,6 +922,7 @@
                                  }
                                  completion:^(BOOL finished){
                                      navigation.hidden = YES;
+                                     [self resetScrollView];
                                  }];
                 
             }

--- a/Classes/RootViewController.m
+++ b/Classes/RootViewController.m
@@ -504,7 +504,7 @@
         if (navigation != nil && !navigation.hidden)
             return CGRectMake(pageWidth * (page - 1), 0, pageWidth, pageHeight - 200);
         else
-            return CGRectMake(pageWidth * (page - 1), 0, pageWidth, pageHeight - 200);
+            return CGRectMake(pageWidth * (page - 1), 0, pageWidth, pageHeight);
     }
     else return CGRectMake(pageWidth * (page - 1), 0, pageWidth, pageHeight);
 }

--- a/Classes/RootViewController.m
+++ b/Classes/RootViewController.m
@@ -617,7 +617,7 @@
         }
         
         if (navigation == webView) {
-            [self performSelector:@selector(toggleNavigationBar) withObject:nil];
+            [self performSelector:@selector(hideNavigationBar) withObject:nil];
         }
     }
     
@@ -931,7 +931,9 @@
 }
 
 -(void)hideNavigationBar{
-    [UIView animateWithDuration:0.1
+    scrollView.frame = CGRectMake(0, 0, self.pageWidth, self.pageHeight);
+    scrollView.contentSize = CGSizeMake(pageWidth * totalPages, pageHeight);
+    [UIView animateWithDuration:0.3
                      animations:^{
                          navigation.frame = CGRectMake(0,self.pageHeight,self.pageWidth, 200);
                      }

--- a/README
+++ b/README
@@ -1,7 +1,8 @@
 Project Baker
 HTML5 Ebook framework for iPad/iPhone
 http://bakerframework.com/
-Copyright (C) 2011, Davide Casali, Marco Colombo, Alessandro Morandi
+Copyright (C) 2011, Davide Casali, Marco Colombo, Alessandro Morandi,
+Florian Franke, Orange Sparkle Ball
 Licensed under BSD Opensource License.
 
 

--- a/book/inc/navigation.html
+++ b/book/inc/navigation.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Published with Baker Epub Framework</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <style>
+            body {
+                margin: 0;
+                padding: 0;
+                font-family: Helvetica, Arial, sans-serif;
+                color: white;
+                background: red;
+                width: 3500px;
+            }
+            
+            .page {
+                
+                margin: 0 auto;
+                text-align: center;
+                height: 100px;
+                width: 150px;
+                padding: 50px;
+                float: left;
+            }
+            
+            #page{
+                margin: 0 auto;
+                text-align: center;
+                height: 200px;
+                width: 250px;
+                float: left;
+            }
+            
+            a.about {
+                display: inline-block;
+                color: white;
+            }
+            
+            </style>
+    </head>
+    <body>
+        <div class="page">
+            <p>
+            <a class="about" href="../Book Cover.html">
+                Book Cover            </a>
+            </p>
+        </div>
+        <div class="page">
+            <p>
+            <a class="about" href="../Chapter 01.html">
+                Chapter 1
+            </a>
+            </p>
+        </div>
+        <div class="page">
+            <p>
+            <a class="about" href="../Chapter 02.html">
+                Chapter 2
+            </a>
+            </p>
+        </div>
+        <div class="page">
+            <p>
+            <a class="about" href="../Chapter 03.html">
+                Chapter 3
+            </a>
+            </p>
+        </div>
+        <div class="page">
+            <p>
+            <a class="about" href="../Chapter 04.html">
+                Chapter 4
+            </a>
+            </p>
+        </div>
+        <div class="page">
+            <p>
+            <a class="about" href="../Chapter 05.html">
+                Chapter 5
+            </a>
+            </p>
+        </div>
+        <div class="page">
+            <p>
+            <a class="about" href="../Chapter 06.html">
+                Chapter 6
+            </a>
+            </p>
+        </div>
+        <div class="page">
+            <p>
+            <a class="about" href="../Chapter 07.html">
+                Chapter 7
+            </a>
+            </p>
+        </div>
+        <div class="page">
+            <p>
+            <a class="about" href="../Chapter 08.html">
+                Chapter 8
+            </a>
+            </p>
+        </div>
+        <div class="page">
+            <p>
+            <a class="about" href="../Chapter 09.html">
+                Chapter 9
+            </a>
+            </p>
+        </div>
+        <div class="page">
+            <p>
+            <a class="about" href="../Chapter 10.html">
+                Chapter 10
+            </a>
+            </p>
+        </div>
+        <div class="page">
+            <p>
+            <a class="about" href="../Chapter 11.html">
+                Chapter 11
+            </a>
+            </p>
+        </div>
+        <div class="page">
+            <p>
+            <a class="about" href="../Chapter 12.html">
+                Chapter 12
+            </a>
+            </p>
+        </div>
+        <div id="page">
+            <p>
+            <a class="about" href="../Colophon.html">
+                Built on Baker
+            </a>
+            </p>
+            
+            <!-- 
+             ****************************************************************************************************
+             You don't have to, but the whole Baker team, the contributors and authors would be
+             really pleased if you could add the badge, page or some reference to the project somewhere.
+             Thank you.
+             ****************************************************************************************************
+             -->
+            <a class="about" href="http://bakerframework.com">
+                <img src="../gfx/baker-framework-badge.png" alt="Built with Baker Ebook Framework" />
+            </a>
+        </div>
+
+    </body>
+</html>


### PR DESCRIPTION
Dunno if the Baker team is interested in adding this feature or if it should remain separate, but I pulled together the Navigation bar from Laker Compendium, with a few enhancements to Florian's code:
- LAKER_NAVIGATION constant to turn on and off Laker-style navigation when building a book (so Baker can be distributed with this feature turned off by default)
- LAKER_NAVIGATION_URL is a relative path constant pointing to the expected location for the nav html file from the book root, defaults to inc/navigation.html
- Navigation can be updated by downloaded hpubs (as long as file is in same relative location as the local book)
- Scroll view resizes better when navigation is active
- Navigation properly hides itself on orientation change (so that you don't have to double toggle to get it back)
