### PR TITLE
Fix to allow use of Baker together with ARC-enabled code

### DIFF
--- a/Classes/Properties.h
+++ b/Classes/Properties.h
@@ -45,7 +45,7 @@
 - (id)getFrom:(NSDictionary *)dictionary withKeys:(NSArray *)keys;
 - (id)getFrom:(NSDictionary *)dictionary withFallback:(NSDictionary *)fallbackDictionary withKeys:(NSArray *)keys;
 - (BOOL)loadManifest:(NSString *)filePath;
-- (NSDictionary *)initDefaults;
+- (NSDictionary *)doInitDefaults;
 - (NSDictionary*)dictionaryFromManifestFile:(NSString*)file;
 + (Properties*)properties;
 

--- a/Classes/Properties.m
+++ b/Classes/Properties.m
@@ -47,7 +47,7 @@
     if (self) {
         NSString *filePath = [[NSBundle mainBundle] pathForResource:fileName ofType:@"json"];
         [self loadManifest:filePath];
-        self.defaults = [self initDefaults];
+        self.defaults = [self doInitDefaults];
     }
     return self;
 }
@@ -119,7 +119,7 @@
     }
 }
 
-- (NSDictionary *)initDefaults {
+- (NSDictionary *)doInitDefaults {
     NSString *json = @"{"
         "\"orientation\": \"both\","
         "\"zoomable\": false,"


### PR DESCRIPTION
Method name should only start with 'init' if it is constructor.
