### PR TITLE
Statusbar Improvements & User Agent

### DIFF
--- a/Baker-Info.plist
+++ b/Baker-Info.plist
@@ -36,6 +36,8 @@
 	<string>Baker-32</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIStatusBarHidden</key>
+	<true/>
 	<key>UINewsstandApp</key>
 	<false/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/Classes/BakerAppDelegate.m
+++ b/Classes/BakerAppDelegate.m
@@ -42,6 +42,13 @@
 #pragma mark -
 #pragma mark Application lifecycle
 
++ (void)initialize {
+    // Set user agent (the only problem is that we can't modify the User-Agent later in the program)
+    NSDictionary *dictionnary = [[NSDictionary alloc] initWithObjectsAndKeys:@"Baker-3.2", @"UserAgent", nil];
+    [[NSUserDefaults standardUserDefaults] registerDefaults:dictionnary];
+    [dictionnary release];
+}
+
 // IOS 3 BUG
 // IF "(BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions"
 // THEN "(BOOL) application:(UIApplication*)application handleOpenURL:(NSURL*)url" is never called


### PR DESCRIPTION
The status bar should now be hidden the moment baker is launched rather than it only hiding when baker has fully loaded. I'll be creating a few default images for baker as well when I get a chance.

I've also set a User Agent specifically for Baker. Allows people to enable specific behaviour for a book loaded in the baker app. For example in the case of laker it could hide the navigation at the top when loaded in the app when it detects that the user agent (via. javascript) is set to "Baker-<Baker Version>".
