### PR TITLE
Enable paging of webView with meta-tag

### DIFF
--- a/BakerView/BakerViewController.m
+++ b/BakerView/BakerViewController.m
@@ -1237,6 +1237,9 @@
 
         [self handlePageLoading];
     }
+    
+    /** CHECK IF META TAG SAYS HTML FILE SHOULD BE PAGED **/
+    [webView.scrollView setPagingEnabled:[Utils webViewShouldBePaged:webView]];
 }
 - (void)webView:(UIWebView *)webView hidden:(BOOL)status animating:(BOOL)animating {
 

--- a/BakerView/lib/Utils.h
+++ b/BakerView/lib/Utils.h
@@ -47,4 +47,6 @@
 + (UIColor *)colorWithHexString:(NSString *)stringToConvert;
 + (void)addSkipBackupAttributeToItemAtPath:(NSString *)path;
 
++ (BOOL)webViewShouldBePaged:(UIWebView*)webView;
+
 @end

--- a/BakerView/lib/Utils.m
+++ b/BakerView/lib/Utils.m
@@ -29,6 +29,8 @@
 //  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //  
 
+#define ISPAGED_JS_SNIPPET @"document.getElementsByName('paged')[0].getAttribute('content')"
+
 #import "Utils.h"
 #import <sys/xattr.h>
 
@@ -78,6 +80,12 @@
             }
         }
     }
+}
+
++ (BOOL)webViewShouldBePaged:(UIWebView*)webView {
+    BOOL shouldBePaged = [[webView stringByEvaluatingJavaScriptFromString:ISPAGED_JS_SNIPPET] boolValue];
+    NSLog(@"• Paging for current page is enabled = %d", shouldBePaged);
+    return shouldBePaged;
 }
 
 @end


### PR DESCRIPTION
As I am a big fan of the wired magazine I came across this issue. Some pages are pagingEnabled and some aren't. So I thought this would be a great feature for baker as well. (I already use it in my current project). Simply add
`<meta name="paged" content="YES">``.

If you don't want it to be paged, just get rid of this meta tag or set it to NO. Easy as that. If you like it, merge it, if not hate it :D
