### PR TITLE
Localization

### DIFF
--- a/Baker.xcodeproj/project.pbxproj
+++ b/Baker.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		20CC551D16AD346900DEFB5C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 20CC551F16AD346900DEFB5C /* Localizable.strings */; };
 		9F1FC71316500A47002C8277 /* navigation-bar-bg.png in Resources */ = {isa = PBXBuildFile; fileRef = 9F1FC71116500A47002C8277 /* navigation-bar-bg.png */; };
 		9F1FC71416500A47002C8277 /* navigation-bar-bg@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 9F1FC71216500A47002C8277 /* navigation-bar-bg@2x.png */; };
 		9F1FC7171650102C002C8277 /* shelf-bg-landscape-568h.png in Resources */ = {isa = PBXBuildFile; fileRef = 9F1FC7151650102C002C8277 /* shelf-bg-landscape-568h.png */; };
@@ -37,7 +38,6 @@
 		9FF795A215B4C4F600899E51 /* UIColor+AQGridView.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FF7959615B4C4F600899E51 /* UIColor+AQGridView.m */; };
 		9FF795A715B4C57E00899E51 /* ShelfViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FF795A615B4C57E00899E51 /* ShelfViewController.m */; };
 		AB26005116011D9D00E9AA66 /* BakerBookStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = AB26005016011D9D00E9AA66 /* BakerBookStatus.m */; };
-		AB3496C2166148A400AEB508 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = AB3496BF166148A400AEB508 /* Localizable.strings */; };
 		AB40045315B4B83000D87E2A /* BakerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AB40042B15B4B83000D87E2A /* BakerViewController.m */; };
 		AB40045715B4B83000D87E2A /* back.png in Resources */ = {isa = PBXBuildFile; fileRef = AB40042F15B4B83000D87E2A /* back.png */; };
 		AB40045915B4B83000D87E2A /* back@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = AB40043015B4B83000D87E2A /* back@2x.png */; };
@@ -79,6 +79,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		20CC551E16AD346900DEFB5C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9F1FC71116500A47002C8277 /* navigation-bar-bg.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "navigation-bar-bg.png"; sourceTree = "<group>"; };
 		9F1FC71216500A47002C8277 /* navigation-bar-bg@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "navigation-bar-bg@2x.png"; sourceTree = "<group>"; };
 		9F1FC7151650102C002C8277 /* shelf-bg-landscape-568h.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "shelf-bg-landscape-568h.png"; sourceTree = "<group>"; };
@@ -130,7 +131,6 @@
 		AB26004F16011D9D00E9AA66 /* BakerBookStatus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BakerBookStatus.h; sourceTree = "<group>"; };
 		AB26005016011D9D00E9AA66 /* BakerBookStatus.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BakerBookStatus.m; sourceTree = "<group>"; };
 		AB3496BB1661472A00AEB508 /* UIConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIConstants.h; sourceTree = "<group>"; };
-		AB3496C0166148A400AEB508 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = Localizable.strings; sourceTree = "<group>"; };
 		AB379313161759A900B4C1A3 /* Constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
 		AB40042A15B4B83000D87E2A /* BakerViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BakerViewController.h; sourceTree = "<group>"; };
 		AB40042B15B4B83000D87E2A /* BakerViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BakerViewController.m; sourceTree = "<group>"; };
@@ -277,14 +277,6 @@
 				9FF7959615B4C4F600899E51 /* UIColor+AQGridView.m */,
 			);
 			path = AQGridView;
-			sourceTree = "<group>";
-		};
-		AB3496BC166148A400AEB508 /* en.lproj */ = {
-			isa = PBXGroup;
-			children = (
-				AB3496BF166148A400AEB508 /* Localizable.strings */,
-			);
-			path = en.lproj;
 			sourceTree = "<group>";
 		};
 		AB40042915B4B83000D87E2A /* BakerView */ = {
@@ -445,7 +437,7 @@
 		ABAFB59215AB9A2E002FA498 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
-				AB3496BC166148A400AEB508 /* en.lproj */,
+				20CC551F16AD346900DEFB5C /* Localizable.strings */,
 				BF3CCC9D15D080560087B9CA /* icon */,
 				ABAFB59315AB9A2E002FA498 /* Baker-Info.plist */,
 				ABAFB59715AB9A2E002FA498 /* main.m */,
@@ -537,7 +529,7 @@
 				9F1FC71416500A47002C8277 /* navigation-bar-bg@2x.png in Resources */,
 				9F1FC7171650102C002C8277 /* shelf-bg-landscape-568h.png in Resources */,
 				9F1FC7181650102C002C8277 /* shelf-bg-portrait-568h.png in Resources */,
-				AB3496C2166148A400AEB508 /* Localizable.strings in Resources */,
+				20CC551D16AD346900DEFB5C /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -591,10 +583,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXVariantGroup section */
-		AB3496BF166148A400AEB508 /* Localizable.strings */ = {
+		20CC551F16AD346900DEFB5C /* Localizable.strings */ = {
 			isa = PBXVariantGroup;
 			children = (
-				AB3496C0166148A400AEB508 /* en */,
+				20CC551E16AD346900DEFB5C /* en */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/Baker/en.lproj/Localizable.strings
+++ b/Baker/en.lproj/Localizable.strings
@@ -32,8 +32,8 @@
 "OPENING_TEXT" = "Loading...";
 
 // Archiving alert
-"ARCHIVE_ALERT_TITLE" = "Are you sure you want to archive this item?";
-"ARCHIVE_ALERT_MESSAGE" = "This item will be removed from your device. You may download it at anytime for free.";
+"ARCHIVE_ALERT_TITLE" = "Are you sure you want to archive this issue?";
+"ARCHIVE_ALERT_MESSAGE" = "This issue will be removed from your device. You may download it at anytime for free.";
 "ARCHIVE_ALERT_BUTTON_CANCEL" = "Cancel";
 "ARCHIVE_ALERT_BUTTON_OK" = "Archive";
 

--- a/Baker/en.lproj/Localizable.strings
+++ b/Baker/en.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 
 // Shelf Navigation Title at the top of the main Issues List
-"SHELF_NAVIGATION_TITLE" = "Baker Shelf";
+"SHELF_NAVIGATION_TITLE" = "Shelf";
 
 // Subscription button
 "SUBSCRIBE_BUTTON_TEXT" = "Subscribe";


### PR DESCRIPTION
Here's an improvement to handle Localizations.

Now, you can add a new localization with Xcode and it will create automatically the appropriate localized folder /

Here's the result when you add a new localization

In Xcode
![Capture d e cran 2013-01-21 a 09 59 42](https://f.cloud.github.com/assets/1521015/82448/f982be0c-63a8-11e2-9289-de10f5ecbfa7.png)

![Capture d e cran 2013-01-21 a 09 59 53](https://f.cloud.github.com/assets/1521015/82449/fc5016d4-63a8-11e2-85be-ee75d8dbdb63.png)

In the finder:
![Capture d e cran 2013-01-21 a 10 06 25](https://f.cloud.github.com/assets/1521015/82455/dc041ae6-63a9-11e2-8dc9-32d41453fe26.png)

Note: at the moment, no new localization added. Screen captures are provided to see what happen when you add a new localization.
