### PR TITLE
Fixes issue #730 & #731

### DIFF
--- a/BakerView/BakerViewController.m
+++ b/BakerView/BakerViewController.m
@@ -1195,7 +1195,7 @@
                             NSString *newURL = [replacerRegexp stringByReplacingMatchesInString:oldURL options:0 range:NSMakeRange(0, [oldURL length]) withTemplate:@""];
 
                             NSLog(@"    Opening with updated URL: %@", newURL);
-                            [self loadModalWebView:url];
+                            [self loadModalWebView:[NSURL URLWithString:newURL]];
 
                             return NO;
                         }

--- a/BakerView/ModalViewController.m
+++ b/BakerView/ModalViewController.m
@@ -159,6 +159,7 @@
 - (void)dealloc {
 
     [self.webView stopLoading];
+    [self.webView removeFromSuperview];
     self.webView.delegate = nil;
 
     [btnGoBack release];


### PR DESCRIPTION
1. Provides modalView with regexp'ed newURL (without referrer=Baker in it)
2. Not sure if it's the proper way, but adding removeFromSuperview does delete/erase the webView after closing. For example, now a playing youtube video stops, when modalView is closed.

I'm just starting to learn objective-c, so there might be some pitfalls i'm not aware of :)
