### PR TITLE
Added info button to Shelf navigation bar.

### DIFF
--- a/Baker.xcodeproj/project.pbxproj
+++ b/Baker.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		9FA57FD1164C84E2006DBD5E /* shelf-bg-portrait~iphone.png in Resources */ = {isa = PBXBuildFile; fileRef = 9FA57FC7164C84E2006DBD5E /* shelf-bg-portrait~iphone.png */; };
 		9FAB40DA162B13CF0088E9C1 /* UIColor+Extensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FAB40D9162B13CF0088E9C1 /* UIColor+Extensions.m */; };
 		9FF795A715B4C57E00899E51 /* ShelfViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9FF795A615B4C57E00899E51 /* ShelfViewController.m */; };
+		A05316AB178E283D008982A1 /* info.html in Resources */ = {isa = PBXBuildFile; fileRef = A05316AA178E283D008982A1 /* info.html */; };
 		AB2317D4169F808000BE3BE7 /* PurchasesManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AB2317D3169F808000BE3BE7 /* PurchasesManager.m */; };
 		AB246A3116C5BC6E00715E25 /* NSMutableURLRequest+WebServiceClient.m in Sources */ = {isa = PBXBuildFile; fileRef = AB246A3016C5BC6E00715E25 /* NSMutableURLRequest+WebServiceClient.m */; };
 		AB26005116011D9D00E9AA66 /* BakerBookStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = AB26005016011D9D00E9AA66 /* BakerBookStatus.m */; };
@@ -102,6 +103,7 @@
 		9FAB40D9162B13CF0088E9C1 /* UIColor+Extensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIColor+Extensions.m"; sourceTree = "<group>"; };
 		9FF795A515B4C57D00899E51 /* ShelfViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ShelfViewController.h; sourceTree = "<group>"; };
 		9FF795A615B4C57E00899E51 /* ShelfViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ShelfViewController.m; sourceTree = "<group>"; };
+		A05316AA178E283D008982A1 /* info.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = info.html; sourceTree = "<group>"; };
 		AB2317D2169F808000BE3BE7 /* PurchasesManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PurchasesManager.h; sourceTree = "<group>"; };
 		AB2317D3169F808000BE3BE7 /* PurchasesManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PurchasesManager.m; sourceTree = "<group>"; };
 		AB246A2F16C5BC6E00715E25 /* NSMutableURLRequest+WebServiceClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableURLRequest+WebServiceClient.h"; sourceTree = "<group>"; };
@@ -344,6 +346,7 @@
 				9F58D85015D66E870027902C /* UICustomNavigationController.m */,
 				ABF23B1B1708418E003AA3B0 /* BakerAPI.h */,
 				ABF23B1C1708418E003AA3B0 /* BakerAPI.m */,
+				A05316AA178E283D008982A1 /* info.html */,
 			);
 			path = BakerShelf;
 			sourceTree = "<group>";
@@ -492,6 +495,7 @@
 				9F1FC7171650102C002C8277 /* shelf-bg-landscape-568h.png in Resources */,
 				9F1FC7181650102C002C8277 /* shelf-bg-portrait-568h.png in Resources */,
 				20CC551D16AD346900DEFB5C /* Localizable.strings in Resources */,
+				A05316AB178E283D008982A1 /* info.html in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Baker/en.lproj/Localizable.strings
+++ b/Baker/en.lproj/Localizable.strings
@@ -6,6 +6,9 @@
 "PRODUCTS_REQUEST_FAILED_TITLE" = "Failure connecting to the App Store";
 "PRODUCTS_REQUEST_FAILED_CLOSE" = "Close";
 
+// Info button
+"INFO_BUTTON_TEXT" = "Info";
+
 // Subscription button
 "SUBSCRIBE_BUTTON_TEXT" = "Subscribe";
 "SUBSCRIBE_BUTTON_DISABLED_TEXT" = "Subscribing...";

--- a/BakerShelf/ShelfViewController.m
+++ b/BakerShelf/ShelfViewController.m
@@ -41,6 +41,10 @@
 #import "Utils.h"
 
 @implementation ShelfViewController
+{
+    __weak UIPopoverController *infoPopover;
+}
+
 
 @synthesize issues;
 @synthesize issueViewControllers;
@@ -214,6 +218,15 @@
     }
     self.navigationItem.leftBarButtonItems = buttonItems;
     #endif
+    
+    UIBarButtonItem *infoButton = [[[UIBarButtonItem alloc]
+                                    initWithTitle: NSLocalizedString(@"INFO_BUTTON_TEXT", nil)
+                                    style:UIBarButtonItemStylePlain
+                                    target:self
+                                    action:@selector(handleInfoButtonPressed:)]
+                                   autorelease];
+    // Remove this line if you don't want the info button to be added to the shelf navigation bar.
+    self.navigationItem.rightBarButtonItem = infoButton;
 }
 - (void)viewDidAppear:(BOOL)animated
 {
@@ -406,6 +419,44 @@
 }
 
 #pragma mark - Store Kit
+- (void)handleInfoButtonPressed:(id)sender {
+    
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
+    {
+        if ([infoPopover isPopoverVisible])
+        {
+            [infoPopover dismissPopoverAnimated:YES];
+            return;
+        }
+    }
+    
+    UIViewController *popoverContent = [[UIViewController alloc] init];
+    UIWebView *popoverView = [[UIWebView alloc] init];
+    popoverView.backgroundColor = [UIColor blackColor];
+    popoverContent.view = popoverView;
+    
+    NSString *path = [[NSBundle mainBundle] pathForResource:@"info" ofType:@"html"];
+    NSFileHandle *readHandle = [NSFileHandle fileHandleForReadingAtPath:path];
+    NSString *htmlString = [[NSString alloc] initWithData:[readHandle readDataToEndOfFile] encoding:NSUTF8StringEncoding];
+    NSURL *mainBundleURL = [NSURL fileURLWithPath:[[NSBundle mainBundle] bundlePath]];
+    [popoverView loadHTMLString:htmlString baseURL:mainBundleURL];
+    
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
+    {
+        infoPopover = [[UIPopoverController alloc] initWithContentViewController:popoverContent];
+        [infoPopover presentPopoverFromBarButtonItem:sender
+                            permittedArrowDirections:UIPopoverArrowDirectionUp
+                                            animated:YES];
+    }
+    else {
+        [self.navigationController pushViewController:popoverContent animated:YES];
+    }
+    
+    [htmlString release];
+    [popoverView release];
+    [popoverContent release];
+}
+
 
 - (void)handleSubscribeButtonPressed:(NSNotification *)notification {
     if (subscriptionsActionSheet.visible) {

--- a/BakerShelf/info.html
+++ b/BakerShelf/info.html
@@ -1,0 +1,37 @@
+<html>
+    <head>
+        <style>
+            body {
+                background-color:#fff;
+                color: #111;
+                margin: 15px;
+                font-family: Helvetica;
+            }
+            p {
+                
+            }
+            h1, h2 {
+                font-family: Helvetica-Bold;
+            }
+            h1 {
+                color: #b72529;
+            }
+            h2 {
+            }
+            
+            </style>
+    </head>
+    <body>
+        <h1>About <em>Baker</em></h1>
+        <p>This is some really useful information for users of your publication.</p>
+        
+        <p>You can put info here about your publication, subscription model, or how awesome you are.</p>
+        
+        <h2>How do I change this text?</h2>
+        
+        <p>The file <tt>info.html</tt> in the BakerShelf folder is a simple HTML file that displays right here. Edit it to your heart's content.</p>
+        
+        <p>If you want to remove it entirely, simply disable the Info button in the <tt>- (void)viewWillAppear:(BOOL)animated</tt> method.</p>
+        
+    </body>
+</html>


### PR DESCRIPTION
On tapping the info button, we display an HTML popover (iPad) or a new view (iPhone) for custom app info. Text for the popover/view is sourced from info.html.

This addition can be seen in The Briefing app, cf. #991.
