### PR TITLE
Separate publication manifest for testing and production

### DIFF
--- a/BakerShelf/Constants.h
+++ b/BakerShelf/Constants.h
@@ -52,6 +52,16 @@
         #define NEWSSTAND_MANIFEST_URL @"http://bakerframework.com/demo/shelf.json"
 
         // ----------------------------------------------------------------------------------------------------
+        // Optional - This redefinition means you can have separate publication records for testing and
+        // production. This is useful for when you've already published your app, but want to
+        // test a new issue on your device before releasing it to everyone else.
+        // It will require you setting up an alternative JSON file on your server.
+        #ifdef DEBUG
+            #undef NEWSSTAND_MANIFEST_URL
+            #define NEWSSTAND_MANIFEST_URL @"http://bakerframework.com/testing/shelf.json"
+        #endif
+
+        // ----------------------------------------------------------------------------------------------------
         // Optional - This constant specifies the URL to ping back when a user purchases an issue or a subscription.
         // For more information, see: https://github.com/Simbul/baker/wiki/Baker-Server-API
         // E.g. @"http://example.com/purchased"


### PR DESCRIPTION
If the app is built in DEBUG mode, use an alternative Shelf Manifest URL.

This is required once you've got your app published on the store to test & proof-read new issues. Place them first in the testing publication, then once they pass QA, insert them into the production publication for the rest of the world to see.

(NB: if all issues in this testing publication are free, checking through Apple is bypassed and you don't need to create new records in iTunes Connect.)
