### PR TITLE
Fix: Javascript error when there's no meta named 'paged'

### DIFF
--- a/BakerView/lib/Utils.m
+++ b/BakerView/lib/Utils.m
@@ -29,7 +29,11 @@
 //  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //
 
-#define ISPAGED_JS_SNIPPET @"document.getElementsByName('paged')[0].getAttribute('content')"
+#define ISPAGED_JS_SNIPPET @"\
+    var elem = document.getElementsByName('paged')[0];\
+    if (elem) {\
+        elem.value = elem.getAttribute('content');\
+    }"
 
 #import "Utils.h"
 #import <sys/xattr.h>


### PR DESCRIPTION
The error was thrown because the code tried to get an attribute of an undefined element.

This fix solves the issue.
